### PR TITLE
updated version of traceur to ~0.0.72

### DIFF
--- a/lib/instrumenter.js
+++ b/lib/instrumenter.js
@@ -6,14 +6,14 @@ Object.defineProperties(exports, {
   __esModule: {value: true}
 });
 var $__istanbul__,
-    $__traceur_64_0_46_0_46_58__,
+    $__traceur_64_0_46_0_46_74__,
     $__esprima__,
     $__escodegen__,
     $__source_45_map__,
     $__fs__,
     $__path__;
 var istanbul = ($__istanbul__ = require("istanbul"), $__istanbul__ && $__istanbul__.__esModule && $__istanbul__ || {default: $__istanbul__}).default;
-var traceur = ($__traceur_64_0_46_0_46_58__ = require("traceur"), $__traceur_64_0_46_0_46_58__ && $__traceur_64_0_46_0_46_58__.__esModule && $__traceur_64_0_46_0_46_58__ || {default: $__traceur_64_0_46_0_46_58__}).default;
+var traceur = ($__traceur_64_0_46_0_46_74__ = require("traceur"), $__traceur_64_0_46_0_46_74__ && $__traceur_64_0_46_0_46_74__.__esModule && $__traceur_64_0_46_0_46_74__ || {default: $__traceur_64_0_46_0_46_74__}).default;
 var esprima = ($__esprima__ = require("esprima"), $__esprima__ && $__esprima__.__esModule && $__esprima__ || {default: $__esprima__}).default;
 var escodegen = ($__escodegen__ = require("escodegen"), $__escodegen__ && $__escodegen__.__esModule && $__escodegen__ || {default: $__escodegen__}).default;
 var SourceMap = ($__source_45_map__ = require("source-map"), $__source_45_map__ && $__source_45_map__.__esModule && $__source_45_map__ || {default: $__source_45_map__}).default;
@@ -35,10 +35,6 @@ var Instrumenter = function Instrumenter() {
 };
 var $Instrumenter = Instrumenter;
 ($traceurRuntime.createClass)(Instrumenter, {
-  _setTraceurOptions: function() {
-    traceur.options.modules = 'amd';
-    traceur.options.experimental = true;
-  },
   _createSourceMapConsumer: function(sourceMap) {
     if (typeof sourceMap === 'string') {
       sourceMap = JSON.parse(sourceMap);
@@ -46,22 +42,22 @@ var $Instrumenter = Instrumenter;
     return new SourceMapConsumer(sourceMap);
   },
   _compile: function(code, fileName) {
-    var sourceFile = new SourceFile(fileName, code);
-    var parser = new Parser(sourceFile);
-    var harmonyTree = parser.parseModule();
-    var reporter = new ErrorReporter();
-    var transformer = new FromOptionsTransformer(reporter);
-    var tree = transformer.transform(harmonyTree);
-    if (reporter.hadError()) {
-      throw new Error('Error transforming');
+    var sourceMap = '',
+        compiler,
+        result;
+    ;
+    compiler = new traceur.NodeCompiler({
+      modules: 'amd',
+      sourceMaps: true
+    });
+    try {
+      result = compiler.compile(code, fileName, fileName, '.');
+      sourceMap = compiler.getSourceMap();
+    } catch (e) {
+      throw new Error(e);
     }
-    var sourceMapGenerator = new SourceMapGenerator({file: fileName});
-    var writer = new ParseTreeMapWriter(sourceMapGenerator, {});
-    writer.visitAny(tree);
-    var compiled = writer.toString(tree);
-    var sourceMap = sourceMapGenerator.toString();
     return {
-      code: compiled,
+      code: result,
       map: sourceMap
     };
   },
@@ -77,22 +73,10 @@ var $Instrumenter = Instrumenter;
     }
     return program;
   },
-  _generate: function(program, code, fileName) {
-    var options = this.opts.codeGenerationOptions || {};
-    options.sourceMap = fileName;
-    options.sourceMapWithCode = true;
-    options.sourceContent = code;
-    options.comment = this.opts.preserveComments;
-    return escodegen.generate(program, options);
-  },
   instrumentSync: function(code, fileName) {
-    this._setTraceurOptions();
     var compiled = this._compile(code, fileName);
-    this._traceurMap = this._createSourceMapConsumer(compiled.map);
     var program = this._parse(compiled.code);
-    var generator = this._generate(program, compiled.code, fileName).map;
-    generator.applySourceMap(this._traceurMap);
-    this._sourceMap = this._createSourceMapConsumer(generator.toString());
+    this._sourceMap = this._createSourceMapConsumer(compiled.map);
     return this.instrumentASTSync(program, fileName, code);
   },
   _fixLocation: function(location) {
@@ -100,8 +84,8 @@ var $Instrumenter = Instrumenter;
     location.end = this._sourceMap.originalPositionFor(location.end);
   },
   _checkLocation: function(location) {
-    var filePath = path.resolve(location.start.source);
-    if (!existsSync(filePath)) {
+    var filePath = location.start.source && path.resolve(location.start.source);
+    if (filePath && !existsSync(filePath) || location.start.line === null) {
       location.start = {
         line: 0,
         column: 0
@@ -122,28 +106,28 @@ var $Instrumenter = Instrumenter;
           map = null;
       for (key in statementMap) {
         if (statementMap.hasOwnProperty(key)) {
-          map = statementMap[$traceurRuntime.toProperty(key)];
+          map = statementMap[key];
           this._fixLocation(map);
           this._checkLocation(map);
         }
       }
       for (key in functionMap) {
         if (functionMap.hasOwnProperty(key)) {
-          map = functionMap[$traceurRuntime.toProperty(key)];
+          map = functionMap[key];
           this._fixLocation(map.loc);
           this._checkLocation(map.loc);
         }
       }
       for (key in branchMap) {
         if (branchMap.hasOwnProperty(key)) {
-          var locations = branchMap[$traceurRuntime.toProperty(key)].locations;
+          var locations = branchMap[key].locations;
           for (var i = 0; i < locations.length; i++) {
-            this._fixLocation(locations[$traceurRuntime.toProperty(i)]);
-            this._checkLocation(locations[$traceurRuntime.toProperty(i)]);
+            this._fixLocation(locations[i]);
+            this._checkLocation(locations[i]);
           }
         }
       }
     }
-    return $traceurRuntime.superCall(this, $Instrumenter.prototype, "getPreamble", [sourceCode, emitUseStrict]);
+    return $traceurRuntime.superGet(this, $Instrumenter.prototype, "getPreamble").call(this, sourceCode, emitUseStrict);
   }
 }, {}, istanbul.Instrumenter);

--- a/lib/ismailia.js
+++ b/lib/ismailia.js
@@ -1,13 +1,13 @@
 "use strict";
-var $__traceur_64_0_46_0_46_58__,
+var $__traceur_64_0_46_0_46_74__,
     $__istanbul__,
     $__instrumenter__;
-var traceur = ($__traceur_64_0_46_0_46_58__ = require("traceur"), $__traceur_64_0_46_0_46_58__ && $__traceur_64_0_46_0_46_58__.__esModule && $__traceur_64_0_46_0_46_58__ || {default: $__traceur_64_0_46_0_46_58__}).default;
+var traceur = ($__traceur_64_0_46_0_46_74__ = require("traceur"), $__traceur_64_0_46_0_46_74__ && $__traceur_64_0_46_0_46_74__.__esModule && $__traceur_64_0_46_0_46_74__ || {default: $__traceur_64_0_46_0_46_74__}).default;
 var istanbul = ($__istanbul__ = require("istanbul"), $__istanbul__ && $__istanbul__.__esModule && $__istanbul__ || {default: $__istanbul__}).default;
 var Instrumenter = ($__instrumenter__ = require("./instrumenter"), $__instrumenter__ && $__instrumenter__.__esModule && $__instrumenter__ || {default: $__instrumenter__}).Instrumenter;
 for (var key in istanbul) {
   if (istanbul.hasOwnProperty(key)) {
-    $traceurRuntime.setProperty(exports, key, istanbul[$traceurRuntime.toProperty(key)]);
+    exports[key] = istanbul[key];
   }
 }
 exports.Instrumenter = Instrumenter;

--- a/package.json
+++ b/package.json
@@ -38,17 +38,17 @@
     "esprima": "^1.2.2",
     "istanbul": "^0.3.0",
     "source-map": "^0.1.38",
-    "traceur": "0.0.58"
+    "traceur": "~0.0.72"
   },
   "devDependencies": {
     "gulp": "^3.8.7",
     "gulp-plumber": "^0.6.5",
     "gulp-rimraf": "^0.1.0",
-    "gulp-traceur": "^0.13.0",
+    "gulp-traceur": "~0.14.0",
     "gulp-watch": "^0.7.0",
     "karma": "^0.12.23",
     "karma-chrome-launcher": "^0.1.4",
-    "karma-coverage": "git://github.com/Spote/karma-coverage",
+    "karma-coverage": "git://github.com/jlowcs/karma-coverage",
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "^0.1.5",
     "karma-requirejs": "^0.2.2",


### PR DESCRIPTION
Couldn't get ismailia to work with a more recent version of traceur, so I had to modify the code.

Major changes:
- I use traceur.NodeCompiler to generate code and sourceMap.
- I removed the whole ```generator``` process. I'm not sure why it was needed (maybe for the output of the older version of traceur?).

I'm not a 100% confident on the code. I've tested it with a simple project of mine, and it was working fine, but maybe I'll find some bugs later on.

Beware of the ```karma-coverage``` devDependency that I modified for my own purposes.

I also updated the ```gulp-traceur``` devDependency version to use the most recent version of traceur (the generated code otherwise didn't work).

Hope it helps.